### PR TITLE
feat: partymember, partymemeberRepository구현

### DIFF
--- a/src/main/java/kr/flab/ottsharing/entity/PartyMember.java
+++ b/src/main/java/kr/flab/ottsharing/entity/PartyMember.java
@@ -1,0 +1,50 @@
+package kr.flab.ottsharing.entity;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Entity
+public class PartyMember {
+
+    @Id
+    @JoinColumn(name = "member_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer memberId;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id")
+    private Party party;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+    @Column(name = "created_timestamp")
+    @CreationTimestamp
+    private LocalDateTime createdTime;
+
+}

--- a/src/main/java/kr/flab/ottsharing/repository/PartyMemberRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/PartyMemberRepository.java
@@ -1,0 +1,17 @@
+package kr.flab.ottsharing.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.flab.ottsharing.entity.PartyMember;
+import kr.flab.ottsharing.entity.User;
+
+public interface PartyMemberRepository extends JpaRepository<PartyMember,Integer> {
+
+    List<PartyMember> findByUser(User user);
+
+
+
+
+}

--- a/src/test/java/kr/flab/ottsharing/repository/PartyMemberTest.java
+++ b/src/test/java/kr/flab/ottsharing/repository/PartyMemberTest.java
@@ -1,0 +1,47 @@
+package kr.flab.ottsharing.repository;
+
+import static org.junit.Assert.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.flab.ottsharing.entity.Party;
+import kr.flab.ottsharing.entity.PartyMember;
+import kr.flab.ottsharing.entity.User;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+@TestPropertySource("classpath:application-test.yml")
+@Transactional
+public class PartyMemberTest {
+
+    @Autowired
+    private PartyMemberRepository memberRepo;
+    @Autowired
+    private UserRepository userRepo;
+    @Autowired
+    private PartyRepository partyRepo;
+
+    @Test
+    void 나의파티찾기_테스트(){
+
+        final User user1 = User.builder().userId("유저1").build();
+        final User savedUser = userRepo.save(user1);
+        final Party party = Party.builder().leader(savedUser).ottId("id").ottPassword("pass").build();
+        final Party myparty = partyRepo.save(party);
+        final PartyMember partyMember = PartyMember.builder().user(savedUser).party(myparty).build();
+
+        memberRepo.save(partyMember);
+
+        Party result = memberRepo.findByUser(savedUser).get(0).getParty();
+        assertEquals("1",result.getPartyId());
+
+    }
+
+
+}


### PR DESCRIPTION
* partymember Entity 및 Repository 구현
* '나의 파티 찾기'테스트 만들었음
* partymember entity의 party를 id로 만들려고 하니 복합키에 대한 에러가 발생하여 고치지 못하고 새로운 memberId라는 컬럼을 생성해 id로 지정함